### PR TITLE
fixed type-o in transform.js

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1449,7 +1449,7 @@ else {
 			if (__global.__context && __global.__context.errorHandler)
 				__global.__context.errorHandler(err);
 			else
-				console.error("UNCAUGHT EXCEPTION: " + ex.message + "\n" + ex.stack);
+				console.error("UNCAUGHT EXCEPTION: " + err.message + "\n" + err.stack);
 		}
 	}
 	


### PR DESCRIPTION
The argument to `__trap` is `err`, but was being referred to as `ex`.
