### PR TITLE
"Streamline" future to require one less arg ;)

### DIFF
--- a/lib/future.js
+++ b/lib/future.js
@@ -3,9 +3,16 @@
  * MIT License
  */
 (function(exports) {
-	exports.future = function(fn, args, i) {
-		var done, err, result;
-		var cb = function(e, r) {
+	exports.future = function(args, i) {
+		var fn, cb, done, err, result;
+		if (typeof args === "function") {
+			fn = args;
+			args = i;
+			i = arguments[2];
+		} else {
+			fn = args.callee;
+		}
+		cb = function(e, r) {
 			done = true; err = e, result = r;
 		};
 		args = Array.prototype.slice.call(args);


### PR DESCRIPTION
I was using Streamline's `future()` helper function directly just now, and it seemed redundant to have to re-write the function name for passing it as an arg:

E.g. from your [blog post](http://bjouhier.wordpress.com/2011/04/04/currying-the-callback-or-the-essence-of-futures/):

```
function readFile(path, callback) {
  if (!callback) return future(readFile, arguments, 1);
  // readFile's body
}
```

In general, it seems better to pass `arguments.callee` instead of `readFile` to reduce duplication. E.g. you can change the name of the function without having to remember to update the call to `future()` as well.

But if you do that, it still seems redundant because you're already passing `arguments`!

So I made the simple change to `future()` to support omitting the function, in which case it'll just `arguments.callee`:

```
function readFile(path, callback) {
  if (!callback) return future(arguments);
  // readFile's body
}
```

Much nicer, isn't it? Certainly more "streamlined" to me! ;)

All the tests pass after this change, which means backwards compatibility wasn't broken.

I didn't change the transformation engine -- or it's re-implementation of `future()` as `__future()` -- to this new style, because it appears you've thought of that? At line 1408 of the current transform.js:

```
// unfortunately callee is gone. So we need to pass a function
```

But when I look at generated code, every call to `__future()` does simply pass the equivalent of `arguments.callee`, so I'm not sure if there are simply some edge cases I'm not aware of.

Cheers,
Aseem
