### PR TITLE
Fix #49 - use path.resolve instead of path.join to calculate file path based on CWD.

### DIFF
--- a/lib/compiler/command.js
+++ b/lib/compiler/command.js
@@ -69,7 +69,7 @@ function _run(){
 			if (argv.length < 1) {
 				throw new Error("invalid command line. Try -h for help");
 			}
-			require(path.join(process.cwd(), argv[1]));
+			require(path.resolve(process.cwd(), argv[1]));
 			break;
 		case "compile":
 			compile(function(err) {


### PR DESCRIPTION
Fixing #49 - use path.resolve instead of path.join to calculate file path based on CWD.
