### PR TITLE
Minor style change: ‘on-line’ --> ‘online’.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The _fibers_ option can be activated by passing `--fibers` to the `node-streamli
 setting the `fibers` option when registering streamline 
 (see the `register(options)` function in `streamline/lib/compiler/register`).
  
-# On-line demo
+# Online demo
 
-You can test `streamline.js` directly with the [on-line demo](http://sage.github.com/streamlinejs/examples/streamlineMe/streamlineMe.html)
+You can test `streamline.js` directly with the [online demo](http://sage.github.com/streamlinejs/examples/streamlineMe/streamlineMe.html)
 
 # Installation
 


### PR DESCRIPTION
Everytime I want to show the online Streamline.js generator to someone,
I go to the GitHub page, hit Cmd-F (Ctrl-F) and type ‘online’ with no
results showing up. This is an attempt to alleviate this issue ;)

Donald Knuth on hyphenation in modern words:
http://www-cs-faculty.stanford.edu/~knuth/email.html
