### PR TITLE
Fixing bug: writing undefined to a WritableStream

### DIFF
--- a/lib/streams/server/streams.js
+++ b/lib/streams/server/streams.js
@@ -309,7 +309,11 @@ function WritableStream(emitter, options) {
 	///   Returns `this` for chaining.
 	this.end = function(data, enc) {
 		checkOpen(this);
-		emitter.end(data, enc);
+    if (data !== undefined) {
+      emitter.end(data, enc);
+    } else {
+      emitter.end();
+    }
 		return this;
 	}
 }


### PR DESCRIPTION
There is a bug in the Streamline WritableStream wrapper when it wraps a fs/WritableStream. Calling end on a Streamline WritableStream which wraps a fs/WritableStream results in undefined being written to the file.

Streamline WritableStream's end function calls emitter.end with data and enc, unchecked. https://github.com/Sage/streamlinejs/blob/master/lib/streams/server/streams.js#L312.

Node.JS's fs/WritableStream will write data if arguments.length > 0, https://github.com/joyent/node/blob/master/lib/fs.js#L1342.

This patch simply checks if data is undefined, and calls emitter.end with no arguments if so.
