### PR TITLE
Deep general trampoline

### DIFF
--- a/lib/callbacks/runtime.js
+++ b/lib/callbacks/runtime.js
@@ -15,10 +15,23 @@
 			frame.prev = __g.frame;
 			__g.frame = frame;
 			try {
-				frame.trampo = 1;
-				body();
-				if (typeof frame.trampo === "function") frame.trampo();
-				else frame.trampo = 2; 
+				if(!__g.trampo) {
+					try {
+						__g.trampo = 1;
+						if(!__g.trampos) {
+							__g.trampos = [];
+						}
+						body();
+						var trampo;
+						while(trampo = __g.trampos.shift()) {
+							trampo();
+						}
+					} finally {
+						__g.trampo = 0;
+					}
+				} else {
+					body();
+				}
 			} catch (e) {
 				__setEF(e, frame.prev);
 				__propagate(_, e);
@@ -47,9 +60,10 @@
 		frame.col = col;
 		var ctx = __g.context;
 		return function ___(err, result) {
-			if (trampo && frame.trampo === 1) return frame.trampo = function() { 
-				frame.trampo = 2; return ___(err, result); 
-			};
+			if (trampo && __g.trampo === 1) return __g.trampos.push(function() {
+				__g.trampo = 2; return ___(err, result);
+			});
+			if(__g.trampo === 2) __g.trampo = 1;
 			var oldFrame = __g.frame;
 			__g.frame = frame;
 			__g.context = ctx;


### PR DESCRIPTION
This is the simple modification that I refer to in the commit comment.  For convenience, here is my original comment:
Thank for you so much for doing this! I can't tell you what a huge help this is. Unfortunately, this particular implementation still blows the tiny stack we are dealing with. The reason is because the trampoline happens from the last Streamlined function entered. So if function A calls B which calls C which calls D which then calls a callback, then the callback will be trampolined from D's _func, then if that callback calls E which calls another callback, then that callback will be trampolined from E's __func, and so on. It's _better - the stack doesn't fill up quite as fast, but it still fills up. With a tiny tweak, we can trampoline all the way back to the top of the stack when a callback is called. This makes the trampoline mechanism more like a super fast "process.nextTick()" in the browser, we queue the callback up for execution, then unwind the stack, then call the callback. If you want, I can create a fork with the changes for you to look over?

BTW, this modification solves our problem.  We are now able to run our streamlined code on very limited stack space.

And my commit message:
Modified to use a deep trampoline. When a trampolined callback is invoked, the stack will unwind all the way up to first Streamlined function on the callstack, which will then invoked the trampolined callback. This is, in effect, an efficient "process.nextTick" implementation that works in any environment/browser already supported by Streamline. Streamlined callbacks are added to a queue (rather than having only a single one) in __g.trampos in order to support certain async call patterns.
