### PR TITLE
Add support for Cakefiles!

### DIFF
--- a/examples/misc/Cakefile
+++ b/examples/misc/Cakefile
@@ -1,0 +1,6 @@
+return if not require('streamline/module')(module)
+
+task 'greet', (options, _) ->
+	console.log 'Hello...'
+	setTimeout _, 1000
+	console.log '...world!'

--- a/lib/compiler/register.js
+++ b/lib/compiler/register.js
@@ -62,7 +62,8 @@ exports.trackModule = function(m, options) {
 
 	m.filename = m.filename.replace(/\\/g, '/');
 	var tmp = m.filename.substring(0, m.filename.lastIndexOf('/'));
-	tmp += '/tmp--' + Math.round(Math.random() * 1e9) + path.extname(m.filename);
+	var ext = (path.basename(m.filename) === 'Cakefile') ? '.coffee' : path.extname(m.filename);
+	tmp += '/tmp--' + Math.round(Math.random() * 1e9) + ext;
 	//console.error("WARNING: streamline not registered, re-loading module  " + m.filename + " as " + tmp);
 	exports.register({});
 	fs.writeFileSync(tmp, fs.readFileSync(m.filename, "utf8"), "utf8");


### PR DESCRIPTION
Discussion thread:

http://groups.google.com/group/streamlinejs/browse_thread/thread/71cabdbc8962b030/afcc631faf404b97

In order to not have to manually reimplement much or all of Cake, this pull request achieves Streamlining via the in-file require('streamline/module') directive.

This commit just recognizes Cakefiles as CoffeeScript so that the generated tmp file is outputted with a .coffee extension, which makes things work.

There might be other ways of supporting Streamline in Cakefiles, in particular to avoid the in-file directive, but I'm not sure any are feasible. Still thinking though.
