### PR TITLE
Remove race condition from the compiler's mkdir -p functions

### DIFF
--- a/lib/compiler/compile._js
+++ b/lib/compiler/compile._js
@@ -287,7 +287,15 @@ function mkdirs(_, path) {
 	while (i < segs.length) {
 		var seg = segs[i];
 		p += (i++ ? '/' : '') + seg;
-		if (i > 1 && !_exists(_, p)) fs.mkdir(p, dirMode, _);
+		if (i > 1 && !_exists(_, p)) {
+			try {
+				fs.mkdir(p, dirMode, _);
+			} catch(err) {
+				if (err.code !== 'EEXIST') {
+					throw err;
+				}
+			}
+		}
 	}
 }
 
@@ -323,7 +331,15 @@ function mkdirsSync(path) {
 		i = 0;
 	path.split('/').slice(0, -1).forEach(function(seg) {
 		p += (i++ ? '/' : '') + seg;
-		if (i > 1 && !(fs.existsSync || fspath.existsSync)(p)) fs.mkdirSync(p, dirMode);
+		if (i > 1 && !(fs.existsSync || fspath.existsSync)(p)) {
+			try {
+				fs.mkdirSync(p, dirMode);
+			} catch(err) {
+				if (err.code !== 'EEXIST') {
+					throw err;
+				}
+			}
+		}
 	});
 }
 

--- a/lib/compiler/compile.js
+++ b/lib/compiler/compile.js
@@ -287,7 +287,15 @@ function mkdirs(_, path) { var p, i, segs, seg; var __frame = { name: "mkdirs", 
         var __3 = (i < segs.length); if (__3) {
           seg = segs[i];
           p += (((i++ ? "/" : "")) + seg); return (function __$mkdirs(_) {
-            var __1 = (i > 1); if (!__1) { return _(null, __1); } ; return _exists(__cb(_, __frame, 7, 16, function ___(__0, __3) { var __2 = !__3; return _(null, __2); }, true), p); })(__cb(_, __frame, -282, 6, function ___(__0, __2) { return (function __$mkdirs(__then) { if (__2) { return fs.mkdir(p, dirMode, __cb(_, __frame, 7, 31, __then, true)); } else { __then(); } ; })(function __$mkdirs() { while (__more) { __loop(); }; __more = true; }); }, true)); } else { __break(); } ; }); do { __loop(); } while (__more); __more = true; })(_); });};
+            var __1 = (i > 1); if (!__1) { return _(null, __1); } ; return _exists(__cb(_, __frame, 7, 16, function ___(__0, __3) { var __2 = !__3; return _(null, __2); }, true), p); })(__cb(_, __frame, -282, 6, function ___(__0, __2) { return (function __$mkdirs(__then) { if (__2) { return (function ___(__then) { (function ___(_) { __tryCatch(_, function __$mkdirs() {
+
+                      return fs.mkdir(p, dirMode, __cb(_, __frame, 9, 4, __then, true)); }); })(function ___(err, __result) { __tryCatch(_, function __$mkdirs() { if (err) {
+
+                        if ((err.code !== "EEXIST")) {
+                          return _(err); } ; __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, __then); }); } else { __then(); } ; })(function __$mkdirs() { while (__more) { __loop(); }; __more = true; }); }, true)); } else { __break(); } ; }); do { __loop(); } while (__more); __more = true; })(_); });};
+
+
+
 
 
 
@@ -295,7 +303,7 @@ function subdir(options) {
   return (options.generators ? "generators" : (options.fibers ? "fibers" : "callbacks"));};
 
 
-function cachedTransform(_, content, path, transform, banner, options) { var i, dir, f, transformed; var __frame = { name: "cachedTransform", line: 298 }; return __func(_, this, arguments, cachedTransform, 0, __frame, function __$cachedTransform() {
+function cachedTransform(_, content, path, transform, banner, options) { var i, dir, f, transformed; var __frame = { name: "cachedTransform", line: 306 }; return __func(_, this, arguments, cachedTransform, 0, __frame, function __$cachedTransform() {
     path = path.replace(/\\/g, "/");
     i = path.indexOf("node_modules/");
     if ((i < 0)) { i = path.lastIndexOf("/"); } else {
@@ -323,7 +331,15 @@ function mkdirsSync(path) {
 
   path.split("/").slice(0, -1).forEach(function(seg) {
     p += (((i++ ? "/" : "")) + seg);
-    if (((i > 1) && !((fs.existsSync || fspath.existsSync))(p))) { fs.mkdirSync(p, dirMode); }; });};
+    if (((i > 1) && !((fs.existsSync || fspath.existsSync))(p))) {
+      try {
+        fs.mkdirSync(p, dirMode);
+      } catch (err) {
+        if ((err.code !== "EEXIST")) {
+          throw err; } ; }; } ; });};
+
+
+
 
 
 
@@ -367,10 +383,10 @@ exports.cachedTransformSync = function(content, path, transform, options) {
 
 
 exports.compile = function exports_compile__3(_, paths, options) { var failed, transform, cwd;
-  function _compile(_, path, options) { var stat, ext, jsPath, source, coffee, compiled, matches; var __frame = { name: "_compile", line: 370 }; return __func(_, this, arguments, _compile, 0, __frame, function __$_compile() {
+  function _compile(_, path, options) { var stat, ext, jsPath, source, coffee, compiled, matches; var __frame = { name: "_compile", line: 386 }; return __func(_, this, arguments, _compile, 0, __frame, function __$_compile() {
       return fs.stat(path, __cb(_, __frame, 1, 13, function ___(__0, __3) { stat = __3; return (function __$_compile(__then) {
           if (stat.isDirectory()) {
-            return fs.readdir(path, __cb(_, __frame, 3, 3, function ___(__0, __4) { return __4.forEach_(__cb(_, __frame, 3, 3, __then, true), function __1(_, f) { var __frame = { name: "__1", line: 373 }; return __func(_, this, arguments, __1, 0, __frame, function __$__1() {
+            return fs.readdir(path, __cb(_, __frame, 3, 3, function ___(__0, __4) { return __4.forEach_(__cb(_, __frame, 3, 3, __then, true), function __1(_, f) { var __frame = { name: "__1", line: 389 }; return __func(_, this, arguments, __1, 0, __frame, function __$__1() {
                   return _compile(__cb(_, __frame, 1, 4, _, true), ((path + "/") + f), options); }); }); }, true)); } else { return (function __$_compile(__then) {
 
               if (stat.isFile()) { return (function ___(__then) { (function ___(_) { __tryCatch(_, function __$_compile() {
@@ -381,7 +397,7 @@ exports.compile = function exports_compile__3(_, paths, options) { var failed, t
                             return exports.compileFile(__cb(_, __frame, 11, 5, __then, true), path, options); } else { return (function __$_compile(__then) {
                               if (((ext === ".coffee") && (path[((path.length - ext.length) - 1)] !== "_"))) {
                                 jsPath = (path.substring(0, (path.length - ext.length)) + ".js"); return (function __$_compile(_) {
-                                  var __2 = options.force; if (__2) { return _(null, __2); } ; return mtime(__cb(_, __frame, 14, 26, function ___(__0, __4) { return mtime(__cb(_, __frame, 14, 43, function ___(__0, __5) { var __3 = (__4 > __5); return _(null, __3); }, true), jsPath); }, true), path); })(__cb(_, __frame, -369, 6, function ___(__0, __5) { return (function __$_compile(__then) { if (__5) {
+                                  var __2 = options.force; if (__2) { return _(null, __2); } ; return mtime(__cb(_, __frame, 14, 26, function ___(__0, __4) { return mtime(__cb(_, __frame, 14, 43, function ___(__0, __5) { var __3 = (__4 > __5); return _(null, __3); }, true), jsPath); }, true), path); })(__cb(_, __frame, -385, 6, function ___(__0, __5) { return (function __$_compile(__then) { if (__5) {
                                       return fs.readFile(path, "utf8", __cb(_, __frame, 15, 19, function ___(__0, __6) { source = __6;
                                         coffee = require("../util/require")("coffee-script");
                                         compiled = coffee.compile(source, {
@@ -402,7 +418,7 @@ exports.compile = function exports_compile__3(_, paths, options) { var failed, t
 
 
                         console.error(ex.stack);
-                        failed++; __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, __then); }); } else { __then(); } ; })(__then); } ; })(_); }, true)); }); }; var __frame = { name: "exports_compile__3", line: 369 }; return __func(_, this, arguments, exports_compile__3, 0, __frame, function __$exports_compile__3() {
+                        failed++; __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, __then); }); } else { __then(); } ; })(__then); } ; })(_); }, true)); }); }; var __frame = { name: "exports_compile__3", line: 385 }; return __func(_, this, arguments, exports_compile__3, 0, __frame, function __$exports_compile__3() {
 
 
 
@@ -417,4 +433,4 @@ exports.compile = function exports_compile__3(_, paths, options) { var failed, t
     return paths.forEach_(__cb(_, __frame, 48, 1, function __$exports_compile__3() {
 
 
-      if (failed) { return _(new Error((("errors found in " + failed) + " files"))); } ; _(); }, true), function __1(_, path) { var __frame = { name: "__1", line: 417 }; return __func(_, this, arguments, __1, 0, __frame, function __$__1() { return _compile(__cb(_, __frame, 1, 2, _, true), fspath.resolve(cwd, path), options); }); }); });};
+      if (failed) { return _(new Error((("errors found in " + failed) + " files"))); } ; _(); }, true), function __1(_, path) { var __frame = { name: "__1", line: 433 }; return __func(_, this, arguments, __1, 0, __frame, function __$__1() { return _compile(__cb(_, __frame, 1, 2, _, true), fspath.resolve(cwd, path), options); }); }); });};


### PR DESCRIPTION
Hi Bruno! Thanks for your help earlier this week. Here's another little thing I was able to tackle myself :^) Minor race condition when running multiple concurrent processes that use a ._js file. Maybe there are others?
