### PR TITLE
Return wrapper function with arguments around fstreamline__.create

### DIFF
--- a/lib/fibers/transform.js
+++ b/lib/fibers/transform.js
@@ -200,7 +200,7 @@ function transform(source, options) {
 			catchup(this.start);
 			var idx = getCallback(args, this.lineno);
 			if (idx !== -1 && this.functionForm === 1) {
-				buffer += 'fstreamline__.create(';
+				buffer += '(function(fstreamline_F__) { return function (' + args.join(', ') + ') { return fstreamline_F__.apply(this, arguments); }; })(fstreamline__.create(';
 				++didRewrite;
 			}
 			if (options.generators && idx !== -1) {
@@ -265,7 +265,7 @@ function transform(source, options) {
 			}
 			catchup(this.end);
 			if (idx !== -1 && this.functionForm === 1) {
-				buffer += ', '+ idx+ ')';
+				buffer += ', '+ idx+ '))';
 			}
 
 			// Reset scopes


### PR DESCRIPTION
This restores the ability to detect the formal arguments and arity
of streamline-wrapped functions in fibers mode.  This fixes several
packages (see issues #146, #149) at the cost of an extra function
call per function creation.
