### PR TITLE
add a --version command line option

### DIFF
--- a/lib/compiler/command.js
+++ b/lib/compiler/command.js
@@ -51,11 +51,11 @@ exports.run = function() {
 			break;
 		case '-h':
 		case '--help':
-            options.action = "help";
-            break;
-        case '--version':
-            options.action = "version";
-            break;
+			options.action = "help";
+			break;
+		case '--version':
+			options.action = "version";
+			break;
 		case '--fibers':
 			options.fibers = true;
 			break;
@@ -109,7 +109,7 @@ exports.run = function() {
 		console.log("  -li, --lines-ignore    ignore line numbers");
 		console.log("  -lm, --lines-mark      mark with line numbers");
 		console.log("  -lp, --lines-preserve  preserve line numbers");
-        console.log("  --version              displays the streamline version");
+		console.log("  --version              displays the streamline version");
 		console.log("  -h, --help             displays this help message");
 		console.log("");
 		break;


### PR DESCRIPTION
A nicety so that moving forward, we can easily see what version of streamline we are running. 

Would be great also to have the streamline runtime, in verbose mode, also print the streamline version to the console, for cases where it is invoked via a call to register() as opposed to running _node at the command line. 
