### PR TITLE
Improvements to explicit future error messaging

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -59,6 +59,47 @@ The preprocessor will give you an error if you use it in invalid contexts. If yo
 var __ = require('underscore');
 ```
 
+<a name="no-callback-given-error">
+### I'm getting a "no callback given" error. What does that mean?
+
+It means you've forgotten to pass a callback, and all async functions written with Streamline require one (as of Streamline 0.10).
+
+If you're calling this function from Streamline code as well, you probably just forgot to add a `_` parameter to your call.
+
+``` javascript
+function func(foo, bar, _) {
+    // ...
+}
+
+// will cause this error:
+func(foo, bar);
+
+// fixed:
+func(foo, bar, _);
+```
+
+If you mean to invoke the function asynchronously (i.e. "kick it off"), you can simply pass any regular function as a callback. It's a best practice to pass one anyway for handling errors that arise asynchronously, so that those errors don't get silently ignored or forgotten.
+
+``` javascript
+function handleError(err) {
+    // log it somewhere, or simply throw it to crash the process
+}
+
+console.log('before');
+func(foo, bar, handleError);
+console.log('after');   // will log immediately; won't wait for func() to fully finish
+```
+
+If you mean to get back a Streamline [future](https://github.com/Sage/streamlinejs#futures), you must pass `!_` as the callback.
+
+``` javascript
+var f1 = func(foo1, bar1, !_);
+var f2 = func(foo2, bar2, !_);
+
+var result1 = f1(_);
+var result2 = f2(_);
+```
+
 ### It does not work and I'm not even getting an exception. What's going on?
 
 You may run into this problem with versions <= 0.8. The _futures_ syntax has changed in 0.10 and the new syntax avoids this problem. You will now get an error if you forgot to pass `_` or `!_`.

--- a/lib/callbacks/runtime.js
+++ b/lib/callbacks/runtime.js
@@ -31,7 +31,7 @@
 		__g.oldStyleFutures = oldStyleFutures;
 		function __func(_, __this, __arguments, fn, index, frame, body) {
 			if (typeof _ !== 'function') {
-				if (_ !== false && !__g.oldStyleFutures) throw new Error("invalid argument #" + index + ": you must pass _ or !_ (https://github.com/Sage/streamlinejs/issues/164)");
+				if (_ !== false && !__g.oldStyleFutures) throw new Error("no callback given (argument #" + index + "). If you're a Streamline user, more info: https://github.com/Sage/streamlinejs/blob/master/FAQ.md#no-callback-given-error");
 				return __fut.future.call(__this, fn, __arguments, index);
 			}
 			frame.file = filename;

--- a/lib/fibers-fast/runtime.js
+++ b/lib/fibers-fast/runtime.js
@@ -33,7 +33,7 @@ function create(fn, idx, entering) {
 		var cb = arguments[idx];
 		if (typeof cb !== "function") {
 			if (entering && !cb) cb = arguments[idx] = function(err) { if (err) throw err; };
-			else if (cb !== false) throw new Error("invalid argument #" + idx + ": you must pass _ or !_");
+			else if (cb !== false) throw new Error("no callback given (argument #" + idx + "). If you're a Streamline user, more info: https://github.com/Sage/streamlinejs/blob/master/FAQ.md#no-callback-given-error");
 			return fut.future.call(this, F, arguments, idx);
 		}
 

--- a/lib/fibers/runtime.js
+++ b/lib/fibers/runtime.js
@@ -37,7 +37,7 @@ function createTemplate(fn, idx) {
 	function F() {
 		var cb = arguments[idx];
 		if (typeof cb !== 'function') {
-			if (cb !== false && !globals.oldStyleFutures) throw new Error("invalid argument #" + idx + ": you must pass _ or !_ (see https://github.com/Sage/streamlinejs/issues/164)");
+			if (cb !== false && !globals.oldStyleFutures) throw new Error("no callback given (argument #" + idx + "). If you're a Streamline user, more info: https://github.com/Sage/streamlinejs/blob/master/FAQ.md#no-callback-given-error");
 			return fut.future.call(this, F, arguments, idx);
 		}
 

--- a/lib/util/future.js
+++ b/lib/util/future.js
@@ -16,7 +16,7 @@
 		fn.apply(this, args);
 		return function F(cb) {
 			if (typeof cb !== 'function') {
-				if (cb !== false && !require('streamline/lib/globals').oldStyleFutures) throw new Error("invalid argument #0: you must pass _ or !_ (see https://github.com/Sage/streamlinejs/issues/164)");
+				if (cb !== false && !require('streamline/lib/globals').oldStyleFutures) throw new Error("no callback given (argument #0). If you're a Streamline user, more info: https://github.com/Sage/streamlinejs/blob/master/FAQ.md#no-callback-given-error");
 				return F;
 			}
 			if (done) cb.call(self, err, result);


### PR DESCRIPTION
The current explicit future message makes sense given the implementation:

```
Error: invalid argument #1: you must pass _ or !_ (https://github.com/Sage/streamlinejs/issues/164)
```

But after playing with this and writing up some [best practices](https://gist.github.com/aseemk/7818408), I've realized that this message is misleading:
- The calling code doesn't have to be in Streamline. If it's not, `_` and `!_` don't mean anything to the developer encountering this message. This is particularly significant if you write a module for public consumption (as I do).
- But even if you're calling from your own Streamline code, it's actually not the case that `_` and `!_` are the only two options; you can still pass a regular callback, if you want to run the function async'ly but still handle errors.

So I improved the error message to something regular JS developers would understand, and added (and linked to from the error message) an FAQ entry that dives into detail for Streamline users:

```
Error: no callback given (argument #x). If you're a Streamline user, more info: https://github.com/Sage/streamlinejs/blob/master/FAQ.md#no-callback-given-error
```

You can view the FAQ entry here:

https://github.com/aseemk/streamlinejs/blob/explicit-futures-error-improvements/FAQ.md#no-callback-given-error

All browser tests from `dev.html` pass, but I'm not sure if those tests cover explicit futures.

Hope you find this a valuable change!
# 

I'd have loved to make two further improvements, but I didn't know how best to achieve them.
1. If a user encounters this error, they need to see what function they're calling, and from where, so they can fix it. But the current stack trace begins with an internal Streamline function, so that info doesn't stick out.
   
   ```
   at __func (/path/to/streamline-code.js:2:2475)
   at theStreamlineFunc__4 [as theStreamlineFunc] (/path/to/streamline-code.js:170:14)
   at theCallingFunc (/path/to/calling-code.js:174:4)
   ...
   ```
   
   Is it possible to strip that first line from the stack trace?
2. Not a huge deal, but it'd be great if this error case could detect whether the calling code was in Streamline, and only include the FAQ link in the error message if it was.
   
   One way to detect that would be to inspect the stack trace and look for `._js` / `._coffee`, but (a) I don't know if that's portable across environments and engines, and (b) that wouldn't work if the calling Streamline code was compiled to JS first. Any thoughts or suggestions?

Thanks Bruno!
