### PR TITLE
Support options.callback != '_' in callbacks mode.

### DIFF
--- a/lib/callbacks/transform.js
+++ b/lib/callbacks/transform.js
@@ -309,13 +309,13 @@ if (typeof exports !== 'undefined') {
 	 * Preliminary pass: mark source nodes so we can map line numbers
 	 * Also eliminate _fast_ syntax
 	 */
-	function _isMarker(node) {
-		return node.type === IDENTIFIER && node.value === '_';
-	}
-	function _isStar(node) {
-		return node.type === CALL && _isMarker(node.children[0]) && node.children[1].children.length === 2;
-	}
 	function _removeFast(node, options) {
+		function _isMarker(node) {
+			return node.type === IDENTIFIER && node.value === options.callback;
+		}
+		function _isStar(node) {
+			return node.type === CALL && _isMarker(node.children[0]) && node.children[1].children.length === 2;
+		}
 		// ~_ -> _
 		if (node.type === BITWISE_NOT && _isMarker(node.children[0])) {
 			options.needsTransform = true;


### PR DESCRIPTION
This fixes a bug where `options.callback` was being ignored. In particular, it fixes the bug-part of #183.
