### PR TITLE
Fix other use of _isStar.

### DIFF
--- a/lib/callbacks/transform.js
+++ b/lib/callbacks/transform.js
@@ -345,6 +345,7 @@ if (typeof exports !== 'undefined') {
 			return node;
 		}
 		if (_isStar(node)) {
+			node._isStar = true;
 			options.needsTransform = true;
 			node.children[0].value = _safeName(options.precious, "__rt") + ".streamlinify"
 			return node;
@@ -467,7 +468,9 @@ if (typeof exports !== 'undefined') {
 			node._scope = scope;
 			var async = scope.isAsync();
 			if (!async && node.type !== FUNCTION) {
-				if (node.type === IDENTIFIER && node.value === options.callback && !(_isStar(parent))) throw new Error(node.filename + ": Function contains async calls but does not have _ parameter: " + node.name + " at line " + node.lineno);
+				if (node.type === IDENTIFIER && node.value === options.callback && !parent._isStar) {
+					throw new Error(node.filename + ": Function contains async calls but does not have _ parameter: " + node.name + " at line " + node.lineno);
+				}
 				return _propagate(node, _doIt);
 			}
 


### PR DESCRIPTION
I didn't notice that this function was used somewhere else (oops), so I'm making the `removeFast` pass mark the node as being `_isStar`, and using that stored information.
