### PR TITLE
Coffeescript 1.7 support

### DIFF
--- a/lib/compiler/underscored.js
+++ b/lib/compiler/underscored.js
@@ -206,7 +206,8 @@ function run(options) {
 	//process.execPath = filename;
 
 	// Load the target file and evaluate it as the main module.
-	require.extensions[coffeeExecuting ? '._coffee' : '._js'](mainModule, filename);
+	// The input path should have been resolved to a file, so use its extension.
+	require.extensions[path.extname(filename)](mainModule, filename);
 }
 
 module.exports.run = run;


### PR DESCRIPTION
CoffeeScript 1.7 no longer registers its `require()` `.coffee` handler by default; it now requires explicit registration like Streamline.

So updated the Streamline registration to ensure `.coffee` is registered if we're registering `._coffee`. Tested this with my own node-neo4j module, which has a `util.coffee`. Didn't work before, now does.

Also fixed what I think is a bug: if you run `_coffee` on a non-`._coffee` file, or e.g. on a directory whose index file happens to be `.coffee` or `.js`, it wouldn't work previously, but now it does.
