### PR TITLE
Fix _coffee REPL for CoffeeScript 1.7

### DIFF
--- a/lib/compiler/repl.js
+++ b/lib/compiler/repl.js
@@ -15,12 +15,18 @@ function _getTransform(options) {
 }
 
 exports.run = function(prog, options) {
+	if (prog == "_coffee") {
+		var coffee = require("streamline/lib/util/require")("coffee-script");
+		if (typeof coffee.register === 'function') {
+			coffee.register();
+		}
+	}
+
 	function evaluate(cmd, context, filename, callback) {
 		try {
 			var transform = _getTransform(options);
 			var cmd = cmd.substring(1, cmd.length - 1);
 			if (prog == "_coffee") {
-				var coffee = require("streamline/lib/util/require")("coffee-script");
 				cmd = coffee.compile(cmd, {
 					filename: filename,
 					bare: true


### PR DESCRIPTION
Needs explicit `register()` call here too.

Before:

```
$ _coffee
> console.log require.extensions['.coffee'].toString()
function () {
          throw new Error("Use CoffeeScript.register() or require the coffee-script/register module to require " + ext + " files.");
        }
```

After:

```
$ _coffee
> console.log require.extensions['.coffee'].toString()
function (module, filename) {
    var answer;
    answer = CoffeeScript._compileFile(filename, false);
    return module._compile(answer, filename);
  }
```
