### PR TITLE
Fix empty newline errors in REPL

### DIFF
--- a/lib/compiler/repl.js
+++ b/lib/compiler/repl.js
@@ -16,6 +16,13 @@ function _getTransform(options) {
 
 exports.run = function(prog, options) {
 	function evaluate(cmd, context, filename, callback) {
+		// HACK: prevent empty commands (just newlines) from throwing errors
+		// during transformation. the command itself is wrapped in parens.
+		if (cmd === '(\n)') {
+			callback(null);		// explicitly returning undefined, like node
+			return
+		}
+
 		try {
 			var transform = _getTransform(options);
 			var cmd = cmd.substring(1, cmd.length - 1);


### PR DESCRIPTION
Just press enter to create some newlines. Works with `node` and `coffee`, not with `_node` or `_coffee`.

Before:

```
$ _node
_node> 
Error: error streamlining source: :2:missing operand on line 2
    at Object.exports.transform (/Users/aseemk/Projects/Node/streamlinejs/lib/callbacks/transform.js:1630:10)
    at REPLServer.evaluate [as eval] (/Users/aseemk/Projects/Node/streamlinejs/lib/compiler/repl.js:50:34)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.EventEmitter.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
    at ReadStream.onkeypress (readline.js:99:10)
    at ReadStream.EventEmitter.emit (events.js:98:17)
    at emitKey (readline.js:1095:12)
_node>
```

After:

```
$ _node
_node> 
undefined
_node> 
```
