### PR TITLE
Preserve source tree structure with -o option + CoffeeScript source maps

### DIFF
--- a/lib/callbacks/compile.js
+++ b/lib/callbacks/compile.js
@@ -91,28 +91,39 @@ function mkdirp(_, path) { var __frame = { name: "mkdirp", line: 75 }; return __
 
 
 
-exports.compileFile = function exports_compileFile__1(_, path, options) { var ext, language, basename, relpath, dirname, dstName, mtimeSrc, mtimeDst, transform, banner, content, shebangparse, shebang, le, coffee, transformed, sourceMap, mapFile, mapPath; var __frame = { name: "exports_compileFile__1", line: 94 }; return __func(_, this, arguments, exports_compileFile__1, 0, __frame, function __$exports_compileFile__1() {
+function outputFile(_, inFile, options) { var dirname, outDir, stripped; var __frame = { name: "outputFile", line: 94 }; return __func(_, this, arguments, outputFile, 0, __frame, function __$outputFile() {
+    dirname = fspath.dirname(inFile);
+
+    if (options.outputDir) {
+      if (options.baseDir) {
+        outDir = fspath.join(options.outputDir, fspath.relative(options.baseDir, dirname)); }
+       else {
+        outDir = options.outputDir; } ; }
+
+     else {
+      outDir = dirname; } ;
+
+    return mkdirp(__cb(_, __frame, 12, 1, function __$outputFile() {
+      stripped = fspath.basename(inFile, fspath.extname(inFile));
+      return _(null, fspath.join(outDir, (stripped + ".js"))); }, true), outDir); });};
+
+
+exports.compileFile = function exports_compileFile__1(_, path, options) { var ext, language, basename, relpath, dstName, dirname, mtimeSrc, mtimeDst, transform, banner, content, shebangparse, shebang, le, coffee, transformed, sourceMap, mapFile, mapPath; var __frame = { name: "exports_compileFile__1", line: 111 }; return __func(_, this, arguments, exports_compileFile__1, 0, __frame, function __$exports_compileFile__1() {
     options = _extend({ }, (options || { }));
     ext = fspath.extname(path);
     language = ext.substring(2);
     basename = fspath.basename(path, ext);
     relpath = fspath.relative(".", path);
+    return outputFile(__cb(_, __frame, 6, 15, function ___(__0, __2) { dstName = __2;
+      dirname = fspath.dirname(dstName);
 
-    if (options.outputDir) {
-      dirname = options.outputDir; }
-     else {
-      dirname = fspath.dirname(path); } ;
-
-    return mkdirp(__cb(_, __frame, 12, 1, function __$exports_compileFile__1() {
-
-      dstName = fspath.join(dirname, (basename + ".js"));
-      return mtime(__cb(_, __frame, 15, 16, function ___(__0, __2) { mtimeSrc = __2;
-        return mtime(__cb(_, __frame, 16, 16, function ___(__0, __3) { mtimeDst = __3;
+      return mtime(__cb(_, __frame, 9, 16, function ___(__0, __3) { mtimeSrc = __3;
+        return mtime(__cb(_, __frame, 10, 16, function ___(__0, __4) { mtimeDst = __4;
           transform = _getTransform(options);
 
           banner = _banner(transform.version, options);
           options.sourceName = relpath;
-          return fs.readFile(path, "utf8", __cb(_, __frame, 21, 18, function ___(__0, __4) { content = __4;
+          return fs.readFile(path, "utf8", __cb(_, __frame, 15, 18, function ___(__0, __5) { content = __5;
             shebangparse = parseShebang(content);
             shebang = shebangparse[0];
             le = shebangparse[2];
@@ -140,7 +151,7 @@ exports.compileFile = function exports_compileFile__1(_, path, options) { var ex
 
 
             banner = ((shebang + le) + banner); return (function __$exports_compileFile__1(_) {
-              var __1 = mtimeDst; if (!__1) { return _(null, __1); } ; return fs.readFile(dstName, "utf8", __cb(_, __frame, 49, 34, _, true)); })(__cb(_, __frame, -93, 6, function ___(__0, __5) { transformed = __5;
+              var __1 = mtimeDst; if (!__1) { return _(null, __1); } ; return fs.readFile(dstName, "utf8", __cb(_, __frame, 43, 34, _, true)); })(__cb(_, __frame, -110, 6, function ___(__0, __6) { transformed = __6;
               if ((((transformed && (mtimeSrc < mtimeDst)) && (transformed.substring(0, banner.length) == banner)) && !options.force)) {
                 return _(null, transformed); } ;
 
@@ -149,7 +160,7 @@ exports.compileFile = function exports_compileFile__1(_, path, options) { var ex
 
               transformed = _transform(transform, content, options);
 
-              mapFile = (options.sourceMapFile || ((((dirname + "/") + basename) + ".map")));
+              mapFile = (options.sourceMapFile || fspath.join(dirname, (basename + ".map")));
               if ((typeof transformed == "string")) {
                 transformed = (banner + transformed);
                 if (options.prevMap) {
@@ -172,7 +183,7 @@ exports.compileFile = function exports_compileFile__1(_, path, options) { var ex
 
 
 
-                    return fs.writeFile(dstName, transformed, "utf8", __cb(_, __frame, 81, 5, __then, true)); }); })(function ___(ex, __result) { __catch(function __$exports_compileFile__1() { if (ex) { __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, function __$exports_compileFile__1() { return (function __$exports_compileFile__1(__then) {
+                    return fs.writeFile(dstName, transformed, "utf8", __cb(_, __frame, 75, 5, __then, true)); }); })(function ___(ex, __result) { __catch(function __$exports_compileFile__1() { if (ex) { __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, function __$exports_compileFile__1() { return (function __$exports_compileFile__1(__then) {
 
                     if (options.sourceMap) {
                       if (options.prevMap) {
@@ -180,7 +191,7 @@ exports.compileFile = function exports_compileFile__1(_, path, options) { var ex
 
 
                             if (options.verbose) { console.log(("streamline: creating: " + mapFile)); } ;
-                            return fs.writeFile(mapFile, sourceMap.toString(), "utf8", __cb(_, __frame, 89, 6, __then, true)); }); })(function ___(ex, __result) { __catch(function __$exports_compileFile__1() { if (ex) { __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, __then); }); } else { __then(); } ; })(_); }); }); }, true)); }, true)); }, true), dstName); }, true), path); }, true), dirname); });};
+                            return fs.writeFile(mapFile, sourceMap.toString(), "utf8", __cb(_, __frame, 83, 6, __then, true)); }); })(function ___(ex, __result) { __catch(function __$exports_compileFile__1() { if (ex) { __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, __then); }); } else { __then(); } ; })(_); }); }); }, true)); }, true)); }, true), dstName); }, true), path); }, true), path, options); });};
 
 
 
@@ -190,7 +201,7 @@ exports.compileFile = function exports_compileFile__1(_, path, options) { var ex
 
 
 
-exports.loadFile = function exports_loadFile__2(_, path, options) { var ext, basename, dirname, js, transform, banner, content, shebangparse, shebang, le, matches; var __frame = { name: "exports_loadFile__2", line: 193 }; return __func(_, this, arguments, exports_loadFile__2, 0, __frame, function __$exports_loadFile__2() {
+exports.loadFile = function exports_loadFile__2(_, path, options) { var ext, basename, dirname, js, transform, banner, content, shebangparse, shebang, le, matches; var __frame = { name: "exports_loadFile__2", line: 204 }; return __func(_, this, arguments, exports_loadFile__2, 0, __frame, function __$exports_loadFile__2() {
     options = _extend({ }, (options || { }));
 
     ext = fspath.extname(path); return (function __$exports_loadFile__2(__then) {
@@ -234,7 +245,7 @@ function cacheRoot(options) {
 
 var dirMode = parseInt("777", 8);
 
-function mkdirs(_, path) { var p, i, segs, seg; var __frame = { name: "mkdirs", line: 237 }; return __func(_, this, arguments, mkdirs, 0, __frame, function __$mkdirs() {
+function mkdirs(_, path) { var p, i, segs, seg; var __frame = { name: "mkdirs", line: 248 }; return __func(_, this, arguments, mkdirs, 0, __frame, function __$mkdirs() {
     p = "";
     i = 0;
     segs = path.split("/").slice(0, -1); return (function ___(__break) { var __more; var __loop = __cb(_, __frame, 0, 0, function __$mkdirs() { __more = false;
@@ -259,7 +270,7 @@ function subdir(options) {
 
 
 
-function cachedTransform(_, content, path, transform, banner, options) { var i, dir, f, transformed; var __frame = { name: "cachedTransform", line: 262 }; return __func(_, this, arguments, cachedTransform, 0, __frame, function __$cachedTransform() {
+function cachedTransform(_, content, path, transform, banner, options) { var i, dir, f, transformed; var __frame = { name: "cachedTransform", line: 273 }; return __func(_, this, arguments, cachedTransform, 0, __frame, function __$cachedTransform() {
     path = path.replace(/\\/g, "/"); return (function __$cachedTransform(__then) {
       if (options.cache) {
         i = path.indexOf("node_modules/");
@@ -286,6 +297,36 @@ function cachedTransform(_, content, path, transform, banner, options) { var i, 
 
 exports.cachedTransformSync = compileSync.cachedTransformSync;
 
+function compileCoffee(_, path, options) { var jsPath, mapPath, outDir, coffeeOpts, source, coffee, compiled, js; var __frame = { name: "compileCoffee", line: 300 }; return __func(_, this, arguments, compileCoffee, 0, __frame, function __$compileCoffee() {
+    return outputFile(__cb(_, __frame, 1, 14, function ___(__0, __2) { jsPath = __2;
+      mapPath = jsPath.replace(/\.js$/, ".map");
+      outDir = fspath.dirname(jsPath);
+      coffeeOpts = {
+        filename: path,
+        sourceMap: options.sourceMap,
+        jsPath: jsPath,
+        sourceRoot: fspath.relative(outDir, "."),
+        sourceFiles: [fspath.relative(".", path),],
+        generatedFile: fspath.basename(jsPath) }; return (function __$compileCoffee(_) {
+
+        var __1 = options.force; if (__1) { return _(null, __1); } ; return mtime(__cb(_, __frame, 12, 22, function ___(__0, __3) { return mtime(__cb(_, __frame, 12, 39, function ___(__0, __4) { var __2 = (__3 > __4); return _(null, __2); }, true), jsPath); }, true), path); })(__cb(_, __frame, -299, 6, function ___(__0, __3) { return (function __$compileCoffee(__then) { if (__3) {
+            return fs.readFile(path, "utf8", __cb(_, __frame, 13, 18, function ___(__0, __4) { source = __4;
+              coffee = require("streamline/lib/util/require")("coffee-script");
+              compiled = coffee.compile(source, coffeeOpts);
+              if (options.verbose) { console.log(((("streamline: coffee compiling: " + path) + " to ") + jsPath)); } ;
+
+              if (options.sourceMap) {
+                js = (((compiled.js + "\n//# sourceMappingURL=") + fspath.basename(mapPath)) + "\n"); }
+               else {
+                js = compiled; } ;
+
+              return fs.writeFile(jsPath, js, "utf8", __cb(_, __frame, 23, 5, function __$compileCoffee() { return (function __$compileCoffee(__then) {
+                  if (options.sourceMap) {
+                    return fs.writeFile(mapPath, compiled.v3SourceMap, "utf8", __cb(_, __frame, 25, 6, __then, true)); } else { __then(); } ; })(__then); }, true)); }, true)); } else { __then(); } ; })(_); }, true)); }, true), path, options); });};
+
+
+
+
 
 
 
@@ -293,35 +334,28 @@ exports.cachedTransformSync = compileSync.cachedTransformSync;
 
 
 exports.compile = function exports_compile__3(_, paths, options) { var failed, transform, cwd;
-  function _compile(_, path, options) { var stat, ext, jsPath, source, coffee, compiled; var __frame = { name: "_compile", line: 296 }; return __func(_, this, arguments, _compile, 0, __frame, function __$_compile() {
-      return fs.stat(path, __cb(_, __frame, 1, 16, function ___(__0, __3) { stat = __3; return (function __$_compile(__then) {
+  function _compile(_, path, base, options) { var stat, ext; var __frame = { name: "_compile", line: 337 }; return __func(_, this, arguments, _compile, 0, __frame, function __$_compile() {
+      return fs.stat(path, __cb(_, __frame, 1, 16, function ___(__0, __2) { stat = __2; return (function __$_compile(__then) {
           if (stat.isDirectory()) {
-            return fs.readdir(path, __cb(_, __frame, 3, 6, function ___(__0, __4) { return __4.forEach_(__cb(_, __frame, 3, 24, __then, true), function __1(_, f) { var __frame = { name: "__1", line: 299 }; return __func(_, this, arguments, __1, 0, __frame, function __$__1() {
-                  return _compile(__cb(_, __frame, 1, 4, function __$__1() { _(); }, true), ((path + "/") + f), options); }); }); }, true)); } else { return (function __$_compile(__then) {
+            base = (base || path);
+            return fs.readdir(path, __cb(_, __frame, 4, 6, function ___(__0, __3) { return __3.forEach_(__cb(_, __frame, 4, 24, __then, true), function __1(_, f) { var __frame = { name: "__1", line: 341 }; return __func(_, this, arguments, __1, 0, __frame, function __$__1() {
+                  return _compile(__cb(_, __frame, 1, 4, function __$__1() { _(); }, true), ((path + "/") + f), base, options); }); }); }, true)); } else { return (function __$_compile(__then) {
 
               if (stat.isFile()) { return (function ___(__then) { (function ___(_) { __tryCatch(_, function __$_compile() {
 
-                      return exports.loadFile(__cb(_, __frame, 8, 12, function __$_compile() {
-                        ext = fspath.extname(path); return (function __$_compile(__then) {
-                          if (((ext === "._js") || (ext === "._coffee"))) {
-                            return exports.compileFile(__cb(_, __frame, 11, 13, __then, true), path, options); } else { return (function __$_compile(__then) {
-                              if (((ext === ".coffee") && (path[((path.length - ext.length) - 1)] !== "_"))) {
-                                jsPath = (path.substring(0, (path.length - ext.length)) + ".js"); return (function __$_compile(_) {
-                                  var __2 = options.force; if (__2) { return _(null, __2); } ; return mtime(__cb(_, __frame, 14, 26, function ___(__0, __4) { return mtime(__cb(_, __frame, 14, 43, function ___(__0, __5) { var __3 = (__4 > __5); return _(null, __3); }, true), jsPath); }, true), path); })(__cb(_, __frame, -295, 6, function ___(__0, __5) { return (function __$_compile(__then) { if (__5) {
-                                      return fs.readFile(path, "utf8", __cb(_, __frame, 15, 22, function ___(__0, __6) { source = __6;
-                                        coffee = require("streamline/lib/util/require")("coffee-script");
-                                        compiled = coffee.compile(source, {
-                                          filename: path });
-
-                                        if (options.verbose) { console.log(((("streamline: coffee compiling: " + path) + " to ") + jsPath)); } ;
-                                        return fs.writeFile(jsPath, compiled, "utf8", __cb(_, __frame, 21, 9, __then, true)); }, true)); } else { __then(); } ; })(__then); }, true)); } else {
+                      ext = fspath.extname(path);
+                      base = (base || fspath.dirname(path));
+                      options.baseDir = base; return (function __$_compile(__then) {
+                        if (((ext === "._js") || (ext === "._coffee"))) {
+                          return exports.compileFile(__cb(_, __frame, 13, 13, __then, true), path, options); } else { return (function __$_compile(__then) {
+                            if (((ext === ".coffee") && (path[((path.length - ext.length) - 1)] !== "_"))) {
+                              return compileCoffee(__cb(_, __frame, 15, 5, __then, true), path, options); } else { __then(); } ; })(__then); } ; })(__then); }); })(function ___(ex, __result) { __catch(function __$_compile() { if (ex) {
 
 
-                                return exports.loadFile(__cb(_, __frame, 24, 13, __then, true), path, options); } ; })(__then); } ; })(__then); }, true), path, options); }); })(function ___(ex, __result) { __catch(function __$_compile() { if (ex) {
 
 
                         console.error(ex.stack);
-                        failed++; __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, __then); }); } else { __then(); } ; })(__then); } ; })(_); }, true)); }); }; var __frame = { name: "exports_compile__3", line: 295 }; return __func(_, this, arguments, exports_compile__3, 0, __frame, function __$exports_compile__3() {
+                        failed++; __then(); } else { _(null, __result); } ; }); }); })(function ___() { __tryCatch(_, __then); }); } else { __then(); } ; })(__then); } ; })(_); }, true)); }); }; var __frame = { name: "exports_compile__3", line: 336 }; return __func(_, this, arguments, exports_compile__3, 0, __frame, function __$exports_compile__3() {
 
 
 
@@ -333,7 +367,7 @@ exports.compile = function exports_compile__3(_, paths, options) { var failed, t
     if (options.verbose) { console.log(("transform version: " + transform.version)); } ;
     if ((!paths || (paths.length == 0))) { return _(new Error("cannot compile: no files specified")); } ;
     cwd = process.cwd();
-    return paths.forEach_(__cb(_, __frame, 41, 7, function __$exports_compile__3() {
+    return paths.forEach_(__cb(_, __frame, 34, 7, function __$exports_compile__3() {
 
 
-      if (failed) { return _(new Error((("errors found in " + failed) + " files"))); } ; _(); }, true), function __1(_, path) { var __frame = { name: "__1", line: 336 }; return __func(_, this, arguments, __1, 0, __frame, function __$__1() { return _compile(__cb(_, __frame, 1, 2, function __$__1() { _(); }, true), fspath.resolve(cwd, path), options); }); }); });};
+      if (failed) { return _(new Error((("errors found in " + failed) + " files"))); } ; _(); }, true), function __1(_, path) { var __frame = { name: "__1", line: 370 }; return __func(_, this, arguments, __1, 0, __frame, function __$__1() { return _compile(__cb(_, __frame, 1, 2, function __$__1() { _(); }, true), fspath.resolve(cwd, path), null, options); }); }); });};

--- a/lib/compiler/build.sh
+++ b/lib/compiler/build.sh
@@ -34,6 +34,6 @@ cd ../..
 TEST=test/common
 bin/_node -lp -v -f --standalone -o $TEST/callbacks/ -c $TEST/{eval,stack,futures}-test._js
 bin/_node -lp -v -f -o $TEST/callbacks/ -c $TEST/flows-test._js
-bin/_node --generators -v -f -o $TEST/generators/ -c $TEST
+bin/_node --generators -v -f -o $TEST/generators/ -c $TEST/*._js
 
 popd > /dev/null

--- a/lib/compiler/compile._js
+++ b/lib/compiler/compile._js
@@ -91,21 +91,32 @@ function mkdirp(_, path) {
 	}
 }
 
+function outputFile(_, inFile, options) {
+	var dirname = fspath.dirname(inFile);
+	var outDir;
+	if (options.outputDir) {
+		if (options.baseDir) {
+			outDir = fspath.join(options.outputDir, fspath.relative(options.baseDir, dirname));
+		} else {
+			outDir = options.outputDir;
+		}
+	} else {
+		outDir = dirname;
+	}
+	mkdirp(_, outDir);
+	var stripped = fspath.basename(inFile, fspath.extname(inFile));
+	return fspath.join(outDir, stripped + ".js");
+}
+
 exports.compileFile = function(_, path, options) {
 	options = _extend({}, options || {});
 	var ext = fspath.extname(path);
 	var language = ext.substring(2);
 	var basename = fspath.basename(path, ext);
 	var relpath = fspath.relative('.', path);
-	var dirname;
-	if (options.outputDir) {
-		dirname = options.outputDir;
-	} else {
-		dirname = fspath.dirname(path);
-	}
-	mkdirp(_, dirname);
+	var dstName = outputFile(_, path, options);
+	var dirname = fspath.dirname(dstName);
 
-	var dstName = fspath.join(dirname, basename + ".js");
 	var mtimeSrc = mtime(_, path);
 	var mtimeDst = mtime(_, dstName);
 	var transform = _getTransform(options);
@@ -149,7 +160,7 @@ exports.compileFile = function(_, path, options) {
 	}
 	var transformed = _transform(transform, content, options);
 	var sourceMap;
-	var mapFile = options.sourceMapFile || (dirname + '/' + basename + ".map");
+	var mapFile = options.sourceMapFile || fspath.join(dirname, basename + ".map");
 	if (typeof transformed == 'string') {
 		transformed = banner + transformed;
 		if (options.prevMap) {
@@ -286,6 +297,36 @@ function cachedTransform(_, content, path, transform, banner, options) {
 
 exports.cachedTransformSync = compileSync.cachedTransformSync;
 
+function compileCoffee(_, path, options) {
+	var jsPath = outputFile(_, path, options);
+	var mapPath = jsPath.replace(/\.js$/, '.map');
+	var outDir = fspath.dirname(jsPath);
+	var coffeeOpts = {
+		filename: path,
+		sourceMap: options.sourceMap,
+		jsPath: jsPath,
+		sourceRoot: fspath.relative(outDir, '.'),
+		sourceFiles: [fspath.relative('.', path)],
+		generatedFile: fspath.basename(jsPath)
+	};
+	if (options.force || mtime(_, path) > mtime(_, jsPath)) {
+		var source = fs.readFile(path, "utf8", ~_);
+		var coffee = require("streamline/lib/util/require")("coffee-script");
+		var compiled = coffee.compile(source, coffeeOpts);
+		if (options.verbose) console.log("streamline: coffee compiling: " + path + " to " + jsPath);
+		var js;
+		if (options.sourceMap) {
+			js = compiled.js + "\n//# sourceMappingURL=" + fspath.basename(mapPath) + "\n";
+		} else {
+			js = compiled;
+		}
+		fs.writeFile(jsPath, js, "utf8", ~_);
+		if (options.sourceMap) {
+			fs.writeFile(mapPath, compiled.v3SourceMap, "utf8", ~_);
+		}
+	}
+}
+
 /// * `compiler.compile(_, paths, options)`  
 ///   Compiles streamline source files in `paths`.  
 ///   Generates a `foo.js` file for each `foo._js` file found in `paths`.
@@ -293,31 +334,24 @@ exports.cachedTransformSync = compileSync.cachedTransformSync;
 ///   will be traversed recursively.  
 ///   `options`  is a set of options for the `transform` operation.
 exports.compile = function(_, paths, options) {
-	function _compile(_, path, options) {
+	function _compile(_, path, base, options) {
 		var stat = fs.stat(path, ~_);
 		if (stat.isDirectory()) {
+			base = base || path;
 			fs.readdir(path, ~_).forEach_(_, function(_, f) {
-				_compile(_, path + "/" + f, options)
+				_compile(_, path + "/" + f, base, options)
 			});
 		} else if (stat.isFile()) {
 			try {
-				exports.loadFile(_, path, options);
 				var ext = fspath.extname(path);
+				base = base || fspath.dirname(path);
+				options.baseDir = base;
 				if (ext === "._js" || ext === "._coffee") {
 					exports.compileFile(_, path, options);
 				} else if (ext === ".coffee" && path[path.length - ext.length - 1] !== '_') {
-					var jsPath = path.substring(0, path.length - ext.length) + ".js";
-					if (options.force || mtime(_, path) > mtime(_, jsPath)) {
-						var source = fs.readFile(path, "utf8", ~_);
-						var coffee = require("streamline/lib/util/require")("coffee-script");
-						var compiled = coffee.compile(source, {
-							filename: path
-						});
-						if (options.verbose) console.log("streamline: coffee compiling: " + path + " to " + jsPath);
-						fs.writeFile(jsPath, compiled, "utf8", ~_);
-					}
+					compileCoffee(_, path, options);
 				} else {
-					exports.loadFile(_, path, options);
+					// not something we can compile
 				}
 			} catch (ex) {
 				console.error(ex.stack);
@@ -334,7 +368,7 @@ exports.compile = function(_, paths, options) {
 	if (!paths || paths.length == 0) throw new Error("cannot compile: no files specified");
 	var cwd = process.cwd();
 	paths.forEach_(_, function(_, path) {
-		_compile(_, fspath.resolve(cwd, path), options);
+		_compile(_, fspath.resolve(cwd, path), null, options);
 	});
 	if (failed) throw new Error("errors found in " + failed + " files");
 };


### PR DESCRIPTION
This allows compiling a whole source tree to JS, with source maps if desired, into a new directory with the same structure. (Previously, using the `-o` option would lead to a flat output directory with every compiled JS file.)

The CoffeeScript compilation feature (for ordinary .coffee files) also now respects the `-m` parameter. This closes #176.

Also removes some seemingly useless `loadFile` calls, speeding up compilation.
