### PR TITLE
Return status code 1 on compile error.

### DIFF
--- a/lib/compiler/command.js
+++ b/lib/compiler/command.js
@@ -112,7 +112,10 @@ exports.run = function() {
 		break;
 	case "compile":
 		require('streamline/lib/callbacks/compile').compile(function(err) {
-			err && console.error(err.message + "\n" + err.stack);
+			if (err) {
+				console.error(err.message + "\n" + err.stack);
+				process.exit(1);
+			}
 		}, options.inputs, options);
 		break;
 	case "help":


### PR DESCRIPTION
Really straightforward change - lets the streamline compiler work properly with build systems.

BTW, can you cut a new release at some point? Would be appreciated :)
