### PR TITLE
Use .streamline.json when running too

### DIFF
--- a/lib/compiler/command.js
+++ b/lib/compiler/command.js
@@ -117,7 +117,7 @@ exports.run = function() {
 			require('./register').register(options);
 			require(path.resolve(process.cwd(), argv[1]));
 		} else {
-			require('./underscored').run(options);
+			require('./register').register(options, /*runAlso:*/ true);
 		}
 		break;
 	case "compile":

--- a/lib/compiler/register.js
+++ b/lib/compiler/register.js
@@ -52,7 +52,7 @@ function loadOptions() {
 	return {};
 }
 
-exports.register = function(setoptions) {
+exports.register = function(setoptions, _runAlso) {
 	if (registered) return;
 	registered = true;
 
@@ -71,8 +71,7 @@ exports.register = function(setoptions) {
 		content = /\._(js|coffee)$/.test(filename) ? content : compile.transformModule(content, filename, _options);
 		return orig.call(this, content, filename);
 	}
-	_options.registerOnly = true;
-	underscored.run(_options);
+
 	if (!_options.fibers && !_options.generators) {
 		var g = require("../globals");
 		require("../callbacks/runtime");
@@ -88,6 +87,10 @@ exports.register = function(setoptions) {
 				break;
 		}
 	}
+
+	// delegate the real registration logic to ./underscored, but register only
+	// unless the caller explicitly wants us to run the main file too:
+	underscored.run(_options, !_runAlso);
 };
 
 Object.defineProperty(exports, "options", {

--- a/lib/compiler/underscored.js
+++ b/lib/compiler/underscored.js
@@ -74,7 +74,7 @@ function registerErrorHandler() {
 	}
 }
 
-function run(options) {
+function run(options, registerOnly) {
 	var subdir = "callbacks";
 	if (options.generators) subdir = options.fast ? "generators-fast" : "generators";
 	else if (options.fibers) subdir = options.fast ? "fibers-fast" : "fibers";
@@ -166,7 +166,7 @@ function run(options) {
 	if (coffeePresent) require.extensions['._coffee'] = streamliners._coffee;
 
 	// If we were asked to register extension handlers only, we're done.
-	if (options.registerOnly) return;
+	if (registerOnly) return;
 
 	// Otherwise, we're being asked to execute (run) a file too.
 	var filename = process.argv[1];


### PR DESCRIPTION
Not just registering. Fixes #195.

This means both running files and running the REPL. And I have to say, this finally feels _amazing_.

Before:

```
$ time _coffee example/
real    0m9.887s
user    0m9.043s
sys 0m0.304s
```

After:

```
$ time _coffee example/
real    0m1.091s
user    0m0.992s
sys 0m0.110s
```

(`example/` is some code of ours, not this repo's `examples` directory.)

I especially love the speedup in the REPL! Because the whole point of the REPL is quick experimentation. =)

PTAL @bjouhier. Lemme know if you'd like the implementation to be any different. Thanks!
