### PR TITLE
use patched source-map-support dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-core": "^6.3.26",
     "babel-plugin-streamline": "^2.0.1",
     "babel-preset-es2015": "^6.3.13",
-    "source-map-support": "^0.3.2",
+    "source-map-support": "git+https://github.com/Sage/node-source-map-support#catch-missing-sourcemap-element",
     "streamline-runtime": "^1.0.15"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Seems very hard to fix the problem outside of `source-map-support`. So I forked it and submitted a PR: https://github.com/evanw/node-source-map-support/pull/123

I modified package.json to point to our patched fork until we can get the fix from NPM.