### PR TITLE
Only extensions

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -28,6 +28,7 @@ function parseOptions(argv) {
 		.option('--runtime <name>', "target runtime")
 		.option('-s, --source-maps <true|false|inline|both>', "(see babel)", /^(true|false|inline|both)$/)
 		.option('--source-map-target <file>', "output file for source map")
+		.option('--only-extensions <exts>', "list of extensions to process (comma-separated)")
 		.option('-q, --quiet', "don't log")
 		.option('--preload <modules>', "hook to preload a specified list of modules (comma-separated)");
 
@@ -91,6 +92,7 @@ function parseOptions(argv) {
 		opts[key] = options[key];
 		return opts;
 	}, {});
+	if (options.onlyExtensions) options.onlyExtensions = options.onlyExtensions.split(',');
 	return util.getOptions(util.extend(util.envOptions(), options));
 };
 
@@ -124,6 +126,7 @@ function runScript(options) {
 	if (!/(\._?(js|coffee)|ts)$/.test(ext)) ext = /^_coffee/.test(fsp.basename(process.argv[1])) ? '._coffee' : '._js';
 	// Update the process argv and execPath too.
 	process.argv = [process.argv[1], filename].concat(options.args.slice(1));
+	if (!require.extensions[ext]) throw new Error("unsupported extension: " + ext);
 	require.extensions[ext](mainModule, filename);
 }
 

--- a/lib/compile._js
+++ b/lib/compile._js
@@ -79,7 +79,7 @@ exports.compile = function(_, paths, options) {
 				base = base || fspath.dirname(path);
 				options.sourceRoot = options.sourceRoot || base;
 				options.filename = path;
-				if (util.canCompile(path)) _compileFile(_, path, options);
+				if (util.canCompile(path, options)) _compileFile(_, path, options);
 			} catch (ex) {
 				console.error(ex.stack);
 				failed++;

--- a/lib/register.js
+++ b/lib/register.js
@@ -97,14 +97,19 @@ exports.register = function(apiOptions) {
 	var options = util.getOptions(apiOptions || util.envOptions());
 
 	try {
+		var extensions = options.onlyExtensions || ['._js', '._coffee', '.ts'].concat(options.extensions || []);
 		// handle CoffeeScript first
-		if (options.extensions && options.extensions.indexOf('.coffee') >= 0)
+		if (extensions.indexOf('.coffee') >= 0)
 			registerCoffee(options, '.coffee');
-		registerCoffee(options, '._coffee');
-		if (options.extensions && options.extensions.indexOf('.js') >= 0)
+		if (extensions.indexOf('._coffee') >= 0)
+			registerCoffee(options, '._coffee');
+		if (extensions.indexOf('.js') >= 0)
 			require.extensions['.js'] = requireHook(options, '.js');
-		require.extensions['._js'] = requireHook(options, '._js');
-		require.extensions['.ts'] = requireHook(options, '.ts');
+		// always register ._Js when compile option is true, because streamline needs it for itself.
+		if (options.compile || extensions.indexOf('._js') >= 0)
+			require.extensions['._js'] = requireHook(options, '._js');
+		if (extensions.indexOf('.ts') >= 0)
+			require.extensions['.ts'] = requireHook(options, '.ts');
 
 		// get globals to ensure requested runtime will be the default
 		require('streamline-runtime/lib/util').getGlobals(options.runtime);

--- a/lib/util.js
+++ b/lib/util.js
@@ -87,7 +87,7 @@ exports.getOptions = function(options) {
 		} else if (/^(lines|standalone|fast|old-style-future|promise|cb|aggressive)$/.test(opt)) {
 			if (!opts.quiet) util.warn('ignoring obsolete option: ' + opt);
 		} else if (/^(compile|outDir|cache|cacheDir|cacheKeep|force|runtime|sourceMaps|sourceMapTarget|quiet|preload|ignore)$/.test(opt) || //
-		/^(args|babel|ext|extensions|sourceRoot)$/.test(opt)) {
+		/^(args|babel|ext|extensions|onlyExtensions|sourceRoot)$/.test(opt)) {
 			// valid option
 			opts[opt] = options[opt];
 		} else if (/^(program|options|rawArgs|args|commands|filename)$/.test(opt)) {
@@ -171,7 +171,12 @@ exports.babelOptions = function(options, filename) {
 	return babelOpts;
 };
 
-exports.canCompile = function(path) {
+exports.canCompile = function(path, options) {
+	// always ignore .d.ts, even if .ts is enabled
+	if (/\.d\.ts/.test(path)) return false;
+	if (options.onlyExtensions) return options.onlyExtensions.some(function(ext) {
+		return path.substring(path.length - ext.length) === ext;
+	});
 	return /\.(_js|_?coffee|ts)$/.test(path);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "streamline",
   "description": "Asynchronous Javascript for dummies",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "license": "MIT",
   "homepage": "http://github.com/Sage/streamlinejs",
   "author": "Bruno Jouhier",


### PR DESCRIPTION
This PR adds a `--only-extensions <exts>` command line option  This option allows you to precisely control the extensions which will be transformed.

for example:
```sh
# will compile *._js and *.ts files but will ignore *._coffee
$ _node --only-extensions ._js,.ts -c examples
```

This option can also be passed to the `register` API. It controls the require hooks that streamline will install. For example:

```js
require('streamline').register({
  onlyExtensions: ["._js", ".ts"]
});
```