### PR TITLE
fix empty lines in repl with node 6

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -7,7 +7,7 @@ exports.run = function(prog, options) {
 	function evaluate(cmd, context, filename, callback) {
 		// HACK: prevent empty commands (just newlines) from throwing errors
 		// during transformation. the command itself is wrapped in parens.
-		if (cmd === '(\n)') {
+		if (cmd === '(\n)' || /^\s*$/.test(cmd)) {
 			callback(null);		// explicitly returning undefined, like node
 			return;
 		}


### PR DESCRIPTION
REPL was broken in node 6: an error was thrown on empty input lines. This PR fixes it