### PR TITLE
Fixed incorrect markdown formatting in FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -59,7 +59,8 @@ The preprocessor will give you an error if you use it in invalid contexts. If yo
 var __ = require('underscore');
 ```
 
-<a name="no-callback-given-error">
+<a name="no-callback-given-error"></a>
+
 ### I'm getting a "cannot call F, expecting a function got ..." error. What does that mean?
 
 It means that you are calling a function written with streamline.js and that you forgot to pass a callback.


### PR DESCRIPTION
Fixed incorrect markdown formatting in FAQ.md

---

The text in current FAQ

```
<a name="no-callback-given-error">
### I'm getting a "cannot call F, expecting a function got ..." error. What does that mean?
```

looks like

<a name="no-callback-given-error">
###I'm getting a "cannot call F, expecting a function got ..." error. What does that mean?

---

Fixed version

```
<a name="no-callback-given-error"></a>

### I'm getting a "cannot call F, expecting a function got ..." error. What does that mean?
```

would look like

<a name="no-callback-given-error"></a>

### I'm getting a "cannot call F, expecting a function got ..." error. What does that mean?