### PR TITLE
Node v14 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 14
   - 12
   - 10
   - 8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamline",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1238,9 +1238,9 @@
       "dev": true
     },
     "fibers": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.2.tgz",
-      "integrity": "sha512-FhICi1K4WZh9D6NC18fh2ODF3EWy1z0gzIdV9P7+s2pRjfRBnCkMDJ6x3bV1DkVymKH8HGrQa/FNOBjYvnJ/tQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
+      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
       "optional": true,
       "requires": {
         "detect-libc": "^1.0.3"
@@ -2183,19 +2183,18 @@
       }
     },
     "streamline-runtime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/streamline-runtime/-/streamline-runtime-2.0.0.tgz",
-      "integrity": "sha512-20IzCmTxRZeFFwoIcnO5u33WV7RfglQJpmnhq0EBMM8KaWA4an9pbmQWE3Eoqzijhq9FbbZvbY2Y3oy4dESmGw==",
+      "version": "git+https://github.com/RivalIQ/streamline-runtime.git#93a1c2643361af284cf5de78e78351f84615c5b7",
+      "from": "git+https://github.com/RivalIQ/streamline-runtime.git#fibers-5.0.0",
       "requires": {
         "colors": "^1.4.0",
-        "fibers": "^4.0.2",
+        "fibers": "^5.0.0",
         "regenerator-runtime": "^0.13.3"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,8 +2183,9 @@
       }
     },
     "streamline-runtime": {
-      "version": "git+https://github.com/RivalIQ/streamline-runtime.git#93a1c2643361af284cf5de78e78351f84615c5b7",
-      "from": "git+https://github.com/RivalIQ/streamline-runtime.git#fibers-5.0.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/streamline-runtime/-/streamline-runtime-3.0.0.tgz",
+      "integrity": "sha512-162H4caVT/VNWCBsCISBOfJBdv9xO3QY9/kQOOH/3Dx3jxjk0RLQSitUWGgiDp56olm4bLVLc6//73CBfpFQzQ==",
       "requires": {
         "colors": "^1.4.0",
         "fibers": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "streamline",
   "description": "Asynchronous Javascript for dummies",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "license": "MIT",
   "homepage": "http://github.com/Sage/streamlinejs",
   "author": "Bruno Jouhier",
@@ -19,7 +19,7 @@
     "colors": "^1.4.0",
     "commander": "^4.0.1",
     "source-map-support": "git+https://github.com/Sage/node-source-map-support.git#catch-missing-sourcemap-element",
-    "streamline-runtime": "^2.0.0",
+    "streamline-runtime": "git+https://github.com/RivalIQ/streamline-runtime#fibers-5.0.0",
     "typescript": "^3.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "colors": "^1.4.0",
     "commander": "^4.0.1",
     "source-map-support": "git+https://github.com/Sage/node-source-map-support.git#catch-missing-sourcemap-element",
-    "streamline-runtime": "git+https://github.com/RivalIQ/streamline-runtime#fibers-5.0.0",
+    "streamline-runtime": "^3.0.0",
     "typescript": "^3.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request supports Node v14 by using recently published streamline-runtime v3.0.0.
- updated `streamline-runtime` to recently published v3.0.0
- added node 14 to travis.yml

related issue:  `streamline-runtime and fibers 5.x` https://github.com/Sage/streamlinejs/issues/382
related pull request: `Node v14 support. Fibers v5.0.0 support ` https://github.com/Sage/streamline-runtime/pull/11

cc: @bjouhier 
