### PR TITLE
fix: pin colors@1.4.0 to fix security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-core": "^6.26.3",
     "babel-plugin-streamline": "^2.0.26",
     "babel-preset-es2015": "^6.24.1",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^4.0.1",
     "source-map-support": "git+https://github.com/Sage/node-source-map-support.git#catch-missing-sourcemap-element",
     "streamline-runtime": "^3.0.0",


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR pins the color package to `1.4.0` as advised on the [snyk page](https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/)